### PR TITLE
Fix Travis CI build

### DIFF
--- a/tests/TimerTest.php
+++ b/tests/TimerTest.php
@@ -12,7 +12,7 @@ class TimerTest extends TestCase
     /** @var string Microtime regular expression */
     protected $microtimeRegex = '/[0-9]{10}(\.[0-9]+)?/';
 
-    public function tearDown()
+    protected function tearDown()
     {
         Timer::reset();
     }


### PR DESCRIPTION
# Changed log
- To be compatible with `PHPUnit\Framework\TestCase::tearDown` method, it should add the return type `void` hint and this will support `php-7.1+` version.
That's why dropping the `php-7.0` version support.
- According to the [Fixtures reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), `PHPUnit\Framework\TestCase::setUp` should be `protected`, not `public`.